### PR TITLE
Rudimentary .travis.yml to run doctests using nose (with coverage reported to codecov)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# vim ft=yaml
+# travis-ci.org definition for python-multihash build
+language: python
+sudo: false
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "pypy"
+  - "pypy3"
+cache:
+  - pip
+
+install:
+  - travis_retry pip install -q codecov nose
+
+script:
+  - nosetests --with-doctest --doctest-tests --with-coverage -s -v multihash.py
+
+after_success:
+  - codecov


### PR DESCRIPTION
well -- as to me, even running tox fails, so I thought it would be valuable to make tests into a CI, thus I would appreciate if you enable travis for this repository. codecov is also really nice to review coverage