### PR TITLE
API Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# python-multihash
-multihash implementation in Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[pycodestyle]
+max-line-length=110
+
+[isort]
+line_length=110
+default_section=THIRDPARTY

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     platforms='POSIX, Windows',
     license='MIT',
     description='multihash implementation in Python',
+    test_suite="tests",
     install_requires=[
         'sha3;python_version<"3.6"',
         'pyblake2;python_version<"3.6"',

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
-from distutils.core import setup
-
+from setuptools import setup
 
 setup(
     name='multihash',
-    version='0.1.1',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     py_modules=['multihash'],
     author='Wijnand Modderman-Lenstra',
     author_email='maze@pyth0n.org',
     maintainer='Wijnand Modderman-Lenstra',
     maintainer_email='maze@pyth0n.org',
     url='https://github.com/tehmaze/python-multihash',
-    keywords='multihash sha1 sha2 sha3 blake2',
+    keywords='multihash',
     platforms='POSIX, Windows',
     license='MIT',
     description='multihash implementation in Python',

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,8 @@ setup(
     platforms='POSIX, Windows',
     license='MIT',
     description='multihash implementation in Python',
+    install_requires=[
+        'sha3;python_version<"3.6"',
+        'pyblake2;python_version<"3.6"',
+    ]
 )

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,71 @@
+import codecs
+import hashlib
+import io
+import sys
+import warnings
+from unittest import TestCase
+
+import multihash
+
+
+class CoreAPITests(TestCase):
+    def test_get_hash_algorithm(self):
+        self.assertEqual(hashlib.sha1, multihash.get_hash_function('sha1'))
+        self.assertEqual(hashlib.sha1, multihash.get_hash_function(0x11))
+        self.assertEqual(hashlib.md5, multihash.get_hash_function('md5'))
+        self.assertEqual(hashlib.md5, multihash.get_hash_function(0xd5))
+
+        self.assertRaises(ValueError, multihash.get_hash_function, 'sha-nonexistent')
+
+    def test_get_hash_algorithm_deprecated(self):
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            self.assertEqual(hashlib.sha3_512, multihash.get_hash_function('sha3'))
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_encode_unicode(self):
+        encoded = multihash.encode('testing', 'sha1')
+        self.assertEqual(22, len(encoded))
+        self.assertEqual(encoded[0], multihash.CODES_BY_NAME['sha1'])
+        self.assertEqual(encoded[1], 0x14)
+        self.assertEqual(encoded[2:], b'\xdcrJ\xf1\x8f\xbd\xd4\xe5\x91\x89\xf5\xfev\x8a_\x83\x11RpP')
+
+    def test_encode_bytes(self):
+        encoded = multihash.encode('testbytes', 'sha1')
+        self.assertEqual(22, len(encoded))
+        self.assertEqual(encoded[0], multihash.CODES_BY_NAME['sha1'])
+        self.assertEqual(encoded[1], 0x14)
+        self.assertEqual(encoded[2:], b't-\x96\x02\x00K"j\xb5!!\xe4\xe4)\xf3\x7f\xd0.\xf7m')
+
+    def test_encode_bufferedreader(self):
+        bytes_io = io.BytesIO(b'TEST BYTES')
+        encoded = multihash.encode(bytes_io, 'sha1')
+        self.assertEqual(22, len(encoded))
+        self.assertEqual(encoded[0], multihash.CODES_BY_NAME['sha1'])
+        self.assertEqual(encoded[1], 0x14)
+        self.assertEqual(encoded[2:], b'G\x85\x18\xd0)\x1f*\xecsI\xc1\xe9_j\xb0OW\xb5\x10\xc9')
+
+    def test_decode(self):
+        encoded = b'\x11\x14\xc3\xd4XGWbx`AAh\x01%\xa4o\xef9Nl('
+        codec_id, decoded = multihash.decode(encoded)
+        self.assertEqual(multihash.CODES_BY_NAME['sha1'], codec_id)
+        self.assertEqual(decoded, bytearray(b'\xc3\xd4XGWbx`AAh\x01%\xa4o\xef9Nl('))
+
+
+class SpecCompatibilityTests(TestCase):
+
+    def test_hardcoded_examples(self):
+        # Source: https://github.com/multiformats/multihash#example
+
+        encoded = multihash.encode("multihash", "sha1")
+        self.assertEqual(encoded, codecs.decode('111488c2f11fb2ce392acb5b2986e640211c4690073e', 'hex_codec'))
+
+        encoded = multihash.encode("multihash", "sha2-256")
+        self.assertEqual(
+            encoded,
+            codecs.decode('12209cbc07c3f991725836a3aa2a581ca2029198aa420b9d99bc0e131d9f3e2cbe47', 'hex_codec')
+        )


### PR DESCRIPTION
I ran into a few points where the current API wasn't quite what I needed. The major changes in this PR:

* Expose hash-function lookup as a public function
* Refactor `decode()` interface to be symmetric so you can easily lookup the hash function used by a particular multihash value without having to partially decode it.
* Add support for efficiently hashing file-like objects and hashing arbitrary byte iterators
* Split the function which actually encodes a (code, digest) pair in the multihash from the helper function which also does content hashing so callers which already have digests can simply format them correctly. This also serves as an extension point for any content types which `encode()` doesn’t know how to handle since the caller will have more knowledge about their source data than a generic library.

There are also some less significant changes:

* Use stdlib hash functions if available with a fallback to
  PyPI dependencies
* Add extra algorithms: MD-5 (backwards compatibility), 
  SHA3-{224,384}
* Add warning for deprecated “sha3” shorthand
* Use identified lengths for blake2 functions
* Add tests: the examples in the [multihash README](https://github.com/multiformats/multihash/blob/master/README.md#example) work, as do the old doctest values. I looked into using the [upstream test-cases](https://github.com/multiformats/multihash/blob/master/tests/values/test_cases.csv) but the input values don't match the outputs so I need to look at the process used to generate them for https://github.com/multiformats/multihash/pull/42 in more detail.
* Automatically install `sha3` and `pyblake2` on old versions of Python so they're always available. The alternative would be to have the lookup function raise a warning on the first call but this seemed preferably for removing barriers to adoption.
* Use [setuptools_scm](https://github.com/pypa/setuptools_scm) to manage the version numbers automatically from Git tags